### PR TITLE
chore: restore E2E checks in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,12 @@ permissions:
   contents: write
 
 jobs:
-  #  e2e:
-  #    uses: ./.github/workflows/pr-checks.yml
-  #    secrets: inherit
+  e2e:
+    uses: ./.github/workflows/pr-checks.yml
+    secrets: inherit
 
   release:
-    #    needs: e2e
+    needs: e2e
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Uncommented the E2E job in  now that the startup failure is resolved (Node.js version fixed).