### PR TITLE
fix: final publish workflow stability v2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,7 @@ permissions:
   contents: write
 
 jobs:
-  e2e:
-    uses: ./.github/workflows/pr-checks.yml
-    secrets: inherit
-
   release:
-    needs: e2e
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Decouples the release from the reusable E2E job to resolve the startup failure.