### PR TITLE
fix(ci): pin Tailscale version to 1.76.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
         uses: tailscale/github-action@v2
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-          version: latest
+          version: 1.76.6
 
       - name: Get RPi Funnel URL (Dynamic)
         id: get_url
@@ -106,7 +106,7 @@ jobs:
         uses: tailscale/github-action@v2
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-          version: latest
+          version: 1.76.6
 
       - name: Build Local Packages
         run: npm run build --workspaces
@@ -325,7 +325,7 @@ jobs:
         uses: tailscale/github-action@v2
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-          version: latest
+          version: 1.76.6
 
       - name: Setup Ansible
         run: |


### PR DESCRIPTION
Fixes SHA256 checksum error in Tailscale GitHub Action.

**Root cause:** `version: latest` triggers a bug where SHA256 checksum validation fails.

**Fix:** Pin to stable version `1.76.6` in all 3 locations (deploy-staging, verify-staging, deploy-prod).

**Verified:** Auth key works locally (RPi visible at 100.94.30.50).