### PR TITLE
fix(ci): check CHANGELOG.md against last tag instead of HEAD~1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,14 +27,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0 # Need full history to find last tag
 
       - name: Verify Changelog Updated
         run: |
-          if git diff --name-only HEAD~1 | grep -q "CHANGELOG.md"; then
-            echo "✅ CHANGELOG.md was updated"
+          # Get the last release tag
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          if [ -z "$LAST_TAG" ]; then
+            echo "✅ No previous tags found, skipping changelog check"
+            exit 0
+          fi
+
+          # Check if CHANGELOG.md was modified since last tag
+          if git diff --name-only "$LAST_TAG" HEAD | grep -q "CHANGELOG.md"; then
+            echo "✅ CHANGELOG.md was updated since $LAST_TAG"
           else
-            echo "❌ ERROR: CHANGELOG.md was NOT updated!"
+            echo "❌ ERROR: CHANGELOG.md was NOT updated since $LAST_TAG!"
             echo "Please update CHANGELOG.md before releasing."
             exit 1
           fi


### PR DESCRIPTION
Fixes changelog check logic to allow multiple commits between changelog update and release trigger.

**Problem:** Previous logic checked `git diff HEAD~1`, which failed when Tailscale fix was committed after changelog update.

**Solution:** Now checks `git diff $LAST_TAG HEAD`, comparing against the last release tag instead of the previous commit.

**Impact:** Allows hotfixes and CI improvements to be committed after changelog without breaking the release gate.