### PR TITLE
fix(ansible): correct regex for Docker build context patching

### DIFF
--- a/packages/cli/templates/ansible/playbooks/deploy-cybermem.yml
+++ b/packages/cli/templates/ansible/playbooks/deploy-cybermem.yml
@@ -113,17 +113,17 @@
         - name: Patch MCP build context
           replace:
             path: "{{ project_dir }}/docker-compose.yml"
-            regexp: 'context:\s+\.\./\.\./mcp'
+            regexp: 'context:\s+\.\.\/\.\.\/mcp'
             replace: "context: ./packages/mcp"
         - name: Patch Dashboard build context
           replace:
             path: "{{ project_dir }}/docker-compose.yml"
-            regexp: 'context:\s+\.\./\.\./dashboard'
+            regexp: 'context:\s+\.\.\/\.\.\/dashboard'
             replace: "context: ./packages/dashboard"
         - name: Patch auth-sidecar build context
           replace:
             path: "{{ project_dir }}/docker-compose.yml"
-            regexp: 'context:\s+\./auth-sidecar'
+            regexp: 'context:\s+\.\/auth-sidecar'
             replace: "context: ./auth-sidecar"
       when: build_from_source | default(false) | bool
 


### PR DESCRIPTION
Closing: superseded by PR #31 (Copilot's fix with proper regex escaping for all dots).